### PR TITLE
Update SWPC link and parsing for solar-geophysical forecast

### DIFF
--- a/web_content.cfg
+++ b/web_content.cfg
@@ -50,16 +50,16 @@
   </ace>
 
   <space_weather>
-    url = http://www.swpc.noaa.gov/today.html
+    url = http://www.swpc.noaa.gov/forecast.html
     <content solar_forecast>
-       pre = Solar Activity Forecast:
-       post = Geophysical Activity Forecast
+       pre = IA.
+       post = IIA.
       <filter>
       </filter>
     </content>
     <content geophys_forecast>
-       pre = Geophysical Activity Forecast:
-       post = Solar X-ray Flux
+       pre = IIA.
+       post = III.
       <filter>
       </filter>
     </content>


### PR DESCRIPTION
The NOAA / Space Weather Prediction Center changed the URL and format for the 3-day solar and geophysical forecast.  This PR changes a single configuration file to fix the URL and provide updated parse information so the forecast information appears in Replan Central again.
