### PR TITLE
Ignore compiler deprecation warnings

### DIFF
--- a/make_timeline.py
+++ b/make_timeline.py
@@ -21,6 +21,12 @@ import tables
 import matplotlib
 matplotlib.use('Agg')
 
+# Ignore compiler warnings that seem to be coming from a django.db
+# interaction (via kadi.events)
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import compiler
 from kadi import events
 import Ska.Numpy
 from Chandra.Time import DateTime


### PR DESCRIPTION
Explicitly silence compiler deprecation warnings that seem to come from django.db via kadi.events in our environment.  