### PR TITLE
Ignore a specific numpy deprecation warning

### DIFF
--- a/make_timeline.py
+++ b/make_timeline.py
@@ -35,6 +35,13 @@ import lineid_plot
 import calc_fluence_dist as cfd
 from Ska.Matplotlib import cxctime2plotdate as cxc2pd
 
+# Ignore known numexpr.necompiler and table.conditions warning
+warnings.filterwarnings(
+    'ignore',
+    message="using `oa_ndim == 0` when `op_axes` is NULL is deprecated.*",
+    category=DeprecationWarning)
+
+
 parser = argparse.ArgumentParser(description='Get ACE data')
 parser.add_argument('--data-dir',
                     default='t_pred_fluence',


### PR DESCRIPTION
Ignore warnings like:
** ERROR - line 245: <<2015-Jun-14 08:01>> /proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/tables/conditions.py:419: DeprecationWarning: using `oa_ndim == 0` when `op_axes` is NULL is deprecated. Use `oa_ndim == -1` or the MultiNew iterator for NumPy <1.8 compatibility