### PR TITLE
Wrap ACE p3 fluence calc and plot in a try/except

### DIFF
--- a/NOTES.change_PR34
+++ b/NOTES.change_PR34
@@ -1,0 +1,48 @@
+Change description and rationale
+--------------------------------
+
+Update Replan Central web page and processing in response to missing ACE P3 data.
+
+The code that makes the interactive plot at top was exiting with an error if ACE p3
+fluence could not be calculated from the available data.  This code change changes that
+behavior so the code will now warn and continue.
+
+Code changes (list affected files and provide code diffs)
+---------------------------------------------------------
+
+This change is the product of one pull requests, 34:
+
+ https://github.com/sot/arc/pull/34/files
+
+Testing
+-------
+
+Ran code in the development environment and verified that processing
+completed with only the expected new warning and that the output web page has the expected
+changes.  Clicked all links and verified expected behavior.  In live testing the MAY0817B
+link was broken, but also appears broken in the approved tool (new issue opened).
+
+ACE p3 data was missing or corrupt on 10-May-2017 and 11-May-2017, so live testing on
+11-May-2017 shows that these code changes work as intended.
+
+
+Interface impacts
+-----------------
+
+Previous code resulted in outdated timeline figure at top; new code has updated figure
+(though fluence values are, as expected, not present).
+
+Review
+------
+
+Code changes by Jean Connelly, internal code review by Tom Aldcroft.
+
+The development version output is available at:
+
+   http://cxc.cfa.harvard.edu/mta/ASPECT/arc_ace_dev/
+
+Deployment plan
+---------------
+
+Will be deployed after approval at a convenient time.
+

--- a/make_timeline.py
+++ b/make_timeline.py
@@ -403,21 +403,25 @@ def main():
     plot_multi_line(x, y, z, [0, 1, 2], ['k', 'r', 'c'], ax)
 
     # Plot 10, 50, 90 percentiles of fluence
-    p3_slope = get_p3_slope(p3_times, p3_vals)
-    if p3_slope is not None and avg_flux > 0:
-        p3_fits, p3_samps, fluences = cfd.get_fluences(
-            os.path.join(args.data_dir, 'ACE_hourly_avg.npy'))
-        hrs, fl10, fl50, fl90 = cfd.get_fluence_percentiles(
-            avg_flux, p3_slope, p3_fits, p3_samps, fluences,
-            args.min_flux_samples, args.max_slope_samples)
-        fluence_hours = (fluence_times - fluence_times[0]) / 3600.0
-        for fl_y, linecolor in zip((fl10, fl50, fl90),
-                                   ('-g', '-b', '-r')):
-            fl_y = Ska.Numpy.interpolate(fl_y, hrs, fluence_hours)
-            rates = np.diff(fl_y)
-            fl_y_atten = calc_fluence(fluence_times[:-1], fluence0, rates, states)
-            zero_fluence_at_radzone(fluence_times[:-1], fl_y_atten, radzones)
-            plt.plot(x0 + fluence_hours[:-1] / 24.0, fl_y_atten, linecolor)
+    try:
+        p3_slope = get_p3_slope(p3_times, p3_vals)
+        if p3_slope is not None and avg_flux > 0:
+            p3_fits, p3_samps, fluences = cfd.get_fluences(
+                os.path.join(args.data_dir, 'ACE_hourly_avg.npy'))
+            hrs, fl10, fl50, fl90 = cfd.get_fluence_percentiles(
+                avg_flux, p3_slope, p3_fits, p3_samps, fluences,
+                args.min_flux_samples, args.max_slope_samples)
+            fluence_hours = (fluence_times - fluence_times[0]) / 3600.0
+            for fl_y, linecolor in zip((fl10, fl50, fl90),
+                                       ('-g', '-b', '-r')):
+                fl_y = Ska.Numpy.interpolate(fl_y, hrs, fluence_hours)
+                rates = np.diff(fl_y)
+                fl_y_atten = calc_fluence(fluence_times[:-1], fluence0, rates, states)
+                zero_fluence_at_radzone(fluence_times[:-1], fl_y_atten, radzones)
+                plt.plot(x0 + fluence_hours[:-1] / 24.0, fl_y_atten, linecolor)
+    except Exception as e:
+        print('WARNING: p3 fluence not plotted, error : {}'.format(e))
+
 
     # Set x and y axis limits
     x0, x1 = cxc2pd([start.secs, stop.secs])


### PR DESCRIPTION
Wrap ACE p3 fluence calc and plot in a try/except .

The try/except with print statement should let make_timeline finish and plot other useful values instead of dying on bad/missing "live" p3 data.
```
File "/proj/sot/ska/share/arc/make_timeline.py", line 412, in main
   args.min_flux_samples, args.max_slope_samples)
File "/proj/sot/ska/share/arc/calc_fluence_dist.py", line 62, in get_fluence_percentiles
    fl10, fl50, fl90 = np.percentile(fluences, [10, 50, 90], axis=0)
...
IndexError: cannot do a non-empty take from an empty axes.
```