### PR TITLE
Use iFOT tsv output instead of HTML table

### DIFF
--- a/iFOT_queries.cfg
+++ b/iFOT_queries.cfg
@@ -9,10 +9,11 @@ timeout = 120          # Timeout for queries to iFOT (seconds)
 <default>
  http    = http://occweb.cfa.harvard.edu/occweb/web/webapps/ifot/ifot.php
  r       = home
- t       = builder
+ t       = qserver
  a       = show
  size    = auto
- format  = list
+ format  = tsv
+ ul      = 7
  columns = type_desc,tstart,tstop,properties
  rel_date_start = -3  # Days before now
  rel_date_stop  =  7  # Days from now


### PR DESCRIPTION
Use iFOT tsv output instead of HTML table

If we run into a problem in the future, it might be good to have this in our back pocket.  It seems to work for me to fetch data and parse, and write out rdb files in initial testing, though I note that the output rdb files seem to have their columns out of order.  