### PR TITLE
Keep the timeline working without hrc data

### DIFF
--- a/arc.pl
+++ b/arc.pl
@@ -32,7 +32,7 @@ use Getopt::Long;
 our $Task     = 'arc3';
 our $TaskData = "$ENV{SKA_DATA}/$Task";
 our $TaskShare = "$ENV{SKA_SHARE}/$Task";
-our $VERSION = '4.1';
+our $VERSION = '4.1.1';
 
 require "$ENV{SKA_SHARE}/$Task/Event.pm";
 require "$ENV{SKA_SHARE}/$Task/Snap.pm";

--- a/arc.pl
+++ b/arc.pl
@@ -515,6 +515,7 @@ sub make_web_page {
 		       Event::format_date(time2date($CurrentTime, 'unix_time')),
 		       " (", Event::calc_local_date($CurrentTime), ")"
 		      );
+    push @warn, 'HRC proxy data are being stubbed out at this time and should be ignored.';
     $html .= make_warning_table(@warn) . $q->p if (@warn);
 
     my $snap_table = make_snap_table($snap) . $q->p;
@@ -551,11 +552,12 @@ sub make_web_page {
 		   $q->img({class=>"boxed", src => $web_data->{goes}{image}{five_min}{file}})
 		  );
 
-    $html .= $q->p({style => $image_title_style},
-		   "GOES proxy for HRC shield rates",
-		   $q->br,
-		   $q->img({class=>"boxed", src => "hrc_shield.png"})
-		  );
+    #$html .= $q->p({style => $image_title_style},
+    #"GOES proxy for HRC shield rates",
+    #$q->br,
+    #$q->img({class=>"boxed", src => "hrc_shield.png"})
+    #);
+    $html .= '<h2 style="color:red;text-align:center">NO data for HRC PROXY</h2>';
 
     $html .= # $q->div({style => 'width:700'},
 		   make_solar_forecast_table($web_data);
@@ -822,7 +824,7 @@ sub make_ephin_goes_table {
     my ($p41gm_proxy, $p41gm_time) = split(' ', io($opt{file}{p41gm})->slurp());
 
     my $warning = ((not defined $p2) || (not defined $p5) || @{$p2} == 0 || @{$p5} == 0) ?
-      '<h2 style="color:red;text-align:center">NO RECENT GOES DATA</h2>' : '';
+      '<h2 style="color:red;text-align:center">NO RECENT GOES DATA<br/> NO data for HRC PROXY</h2>' : '';
 
     my $ephin_date = $snap->{obt}{value} . ' (' .
 		  Event::calc_delta_date($snap->{obt}{value}) . ')';

--- a/make_timeline.py
+++ b/make_timeline.py
@@ -267,7 +267,10 @@ def get_hrc(tstart, tstop):
     hrc = h5.root.data.col('hrc_shield') * 256.0
     ok = (tstart < times) & (times < tstop) & (hrc > 0)
     h5.close()
-    return times[ok], hrc[ok]
+    if np.count_nonzero(ok) < 2:
+        return np.array([tstart, tstop]), np.array([1, 1])
+    else:
+        return times[ok], hrc[ok]
 
 
 def plot_multi_line(x, y, z, bins, colors, ax):

--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -41,8 +41,8 @@ alert       aca@head.cfa.harvard.edu
       exec  5 : $ENV{SKA_SHARE}/arc3/get_web_content.pl
       exec  5 : $ENV{SKA_SHARE}/arc3/get_goes_x.py --h5=$ENV{SKA_DATA}/arc3/GOES_X.h5
       exec  5 : $ENV{SKA_SHARE}/arc3/get_ace.py --h5=$ENV{SKA_DATA}/arc3/ACE.h5
-      exec  5 : $ENV{SKA_SHARE}/arc3/get_hrc.py --data-dir=$ENV{SKA_DATA}/arc3
-      exec  5 : $ENV{SKA_SHARE}/arc3/plot_hrc.py --h5=$ENV{SKA_DATA}/arc3/hrc_shield.h5 --out=$ENV{SKA}/www/ASPECT/arc3/hrc_shield.png
+      # exec  5 : $ENV{SKA_SHARE}/arc3/get_hrc.py --data-dir=$ENV{SKA_DATA}/arc3
+      # exec  5 : $ENV{SKA_SHARE}/arc3/plot_hrc.py --h5=$ENV{SKA_DATA}/arc3/hrc_shield.h5 --out=$ENV{SKA}/www/ASPECT/arc3/hrc_shield.png
       exec  5 : $ENV{SKA_SHARE}/arc3/make_timeline.py --data-dir=$ENV{SKA_DATA}/arc3
       exec  2 : $ENV{SKA_SHARE}/arc3/arc.pl
       exec  2 : $ENV{SKA_SHARE}/arc3/arc.pl -config arc3:arc_ops


### PR DESCRIPTION
Keep the timeline working without hrc data

This is a super-simple edit that puts in two dummy points of hrc data if there is nothing in the hrc_shield.h5 file.

The edit also just comments out the parts of task schedule intended to update the hrc proxy data file.

I've run this in a dev ska to show it completes.
