### PR TITLE
Tweak print error (for accuracy and to not match "failed")

### DIFF
--- a/get_goes_x.py
+++ b/get_goes_x.py
@@ -50,7 +50,7 @@ else:
 try:
     dat = Table(json.loads(urldat))
 except Exception as err:
-    print(('Malformed GOES_X data so table read failed: {}'
+    print(('Malformed GOES_X data from SWPC; Table(json.loads(urldat)) did not succeed: {}'
           .format(err)))
     sys.exit(0)
 


### PR DESCRIPTION
Tweak print error (for accuracy and to not match "failed")

We updated this line to strip the Warning, hoping not to match the watch_cron_logs.  But there's also a search for "failed" in the arc watch_cron_logs and I think we want to keep that to match various Perl fails, so let's tweak this printed warning again.