### PR TITLE
Set to use Net::Netrc for credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,12 +98,12 @@ TEST_DEP = data/arc3/
 install:
 #  Uncomment the lines which apply for this task
 #	mkdir -p $(INSTALL_BIN)
-	mkdir -p $(INSTALL_DATA)
+#	mkdir -p $(INSTALL_DATA)
 	mkdir -p $(INSTALL_SHARE)
 #	mkdir -p $(INSTALL_DOC)
 #	mkdir -p $(INSTALL_LIB)
 #	rsync --times --cvs-exclude $(BIN) $(INSTALL_BIN)/
-	rsync --times --cvs-exclude $(DATA) $(INSTALL_DATA)/
+#	rsync --times --cvs-exclude $(DATA) $(INSTALL_DATA)/
 	rsync --times --cvs-exclude $(SHARE) $(INSTALL_SHARE)/
 #	rsync --times --cvs-exclude $(DOC) $(INSTALL_DOC)/
 #	rsync --times --cvs-exclude $(LIB) $(INSTALL_LIB)/

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SHARE = Event.pm Snap.pm parse_cm_file.pl arc_time_machine.pl \
 	timeline.js timeline.css vert_line.gif \
 	task_schedule.cfg
 
-DATA =	ACE_hourly_avg.npy
+DATA =
 DOC =
 
 include /proj/sot/ska/include/Makefile.FLIGHT

--- a/get_iFOT_events.pl
+++ b/get_iFOT_events.pl
@@ -6,6 +6,7 @@ use warnings;
 use LWP::UserAgent;
 use HTML::TableExtract;
 use IO::All;
+use Net::Netrc;
 use Config::General qw(ParseConfig);
 use Data::Dumper;
 use Ska::Convert qw(:all);
@@ -19,6 +20,7 @@ our $TaskData = "$ENV{SKA_DATA}/$Task";
 our $Debug    = 0;
 our $CurrentTime = time;	# Use time at start of program for output names
 
+
 # Global task options
 our %opt  = ParseConfig(-ConfigFile => "$TaskShare/$Task.cfg");
 
@@ -30,7 +32,9 @@ foreach my $query_id (@{$opt{query_name}}) {
     # Make HTTP web query for iFOT and do it  (NEED to set timeout and deal with it)
     my $query = make_iFOT_query($query_id);
     print "Query = '$query'\n" if $Debug;
-    my ($ifot_user, $ifot_passwd) = Ska::Web::get_user_passwd($ifot{auth_file});
+    my $netrc = Net::Netrc->lookup('occweb');
+    my $ifot_user = $netrc->login;
+    my $ifot_passwd = $netrc->password;
     my $req_html = Ska::Web::get_url($query,
                                      user => $ifot_user,
                                      passwd => $ifot_passwd,

--- a/get_iFOT_events.pl
+++ b/get_iFOT_events.pl
@@ -20,7 +20,6 @@ our $TaskData = "$ENV{SKA_DATA}/$Task";
 our $Debug    = 0;
 our $CurrentTime = time;	# Use time at start of program for output names
 
-
 # Global task options
 our %opt  = ParseConfig(-ConfigFile => "$TaskShare/$Task.cfg");
 

--- a/get_web_content.pl
+++ b/get_web_content.pl
@@ -36,16 +36,11 @@ while (my ($web_name, $web) = each %web_data) {
 
     my %web_opt = map { $_ => $web->{$_} } grep {not ref($web->{$_})} keys %{$web};
 
-    # Get username and password from authorization file(s) (which might be a glob)
-    if (defined $web_opt{auth_file}) {
-	if ($web_opt{auth_file} eq 'occweb'){
-	    my $netrc = Net::Netrc->lookup('occweb');
-	    $web_opt{user} = $netrc->login;
-	    $web_opt{passwd} = $netrc->password;
-	}
-	else{
-	    ($web_opt{user}, $web_opt{passwd}) = Ska::Web::get_user_passwd($web_opt{auth_file})
-	}
+    # Get username and password from netrc if required
+    if (defined $web_opt{netrc}) {
+	my $netrc = Net::Netrc->lookup($web_opt{netrc});
+	$web_opt{user} = $netrc->login;
+	$web_opt{passwd} = $netrc->password;
     }
         
     my ($html, $error, $header) = Ska::Web::get_url($url, %web_opt);

--- a/get_web_content.pl
+++ b/get_web_content.pl
@@ -6,6 +6,7 @@ use strict;
 use Try::Tiny qw(try catch);
 use IO::All;
 use Config::General qw(ParseConfig);
+use Net::Netrc;
 use Data::Dumper;
 use Ska::Convert qw(time2date date2time);
 use Ska::Web;
@@ -37,7 +38,14 @@ while (my ($web_name, $web) = each %web_data) {
 
     # Get username and password from authorization file(s) (which might be a glob)
     if (defined $web_opt{auth_file}) {
-        ($web_opt{user}, $web_opt{passwd}) = Ska::Web::get_user_passwd($web_opt{auth_file})
+	if ($web_opt{auth_file} eq 'occweb'){
+	    my $netrc = Net::Netrc->lookup('occweb');
+	    $web_opt{user} = $netrc->login;
+	    $web_opt{passwd} = $netrc->password;
+	}
+	else{
+	    ($web_opt{user}, $web_opt{passwd}) = Ska::Web::get_user_passwd($web_opt{auth_file})
+	}
     }
         
     my ($html, $error, $header) = Ska::Web::get_url($url, %web_opt);

--- a/iFOT_queries.cfg
+++ b/iFOT_queries.cfg
@@ -18,8 +18,6 @@ timeout = 120          # Timeout for queries to iFOT (seconds)
  rel_date_stop  =  7  # Days from now
 </default>
 
-# User-read-only files with OCC Web user name and password
-auth_file = occweb
 
 # Query definitions
 

--- a/iFOT_queries.cfg
+++ b/iFOT_queries.cfg
@@ -19,7 +19,7 @@ timeout = 120          # Timeout for queries to iFOT (seconds)
 </default>
 
 # User-read-only files with OCC Web user name and password
-auth_file = /proj/sot/ska/data/aspect_authorization/occweb-*
+auth_file = occweb
 
 # Query definitions
 

--- a/web_content.cfg
+++ b/web_content.cfg
@@ -7,7 +7,7 @@
 <orbit_image>
   url = http://occweb.cfa.harvard.edu/occweb/web/webapps/ifot/ifot.php?r=home&t=qserver&format=orbit&detail=properties&fg=000000&bg=F0F1FF&size=300x230&scale=1400&showtimes=false&border=false&ul=6
   add_tstart_tstop = 1
-  auth_file = occweb
+  netrc = occweb
   <content orbit>
     file = chandra_orbit.png
     convert = -transparent \#F0F1FF -crop 200x130+60+50 

--- a/web_content.cfg
+++ b/web_content.cfg
@@ -7,7 +7,7 @@
 <orbit_image>
   url = http://occweb.cfa.harvard.edu/occweb/web/webapps/ifot/ifot.php?r=home&t=qserver&format=orbit&detail=properties&fg=000000&bg=F0F1FF&size=300x230&scale=1400&showtimes=false&border=false&ul=6
   add_tstart_tstop = 1
-  auth_file = /proj/sot/ska/data/aspect_authorization/occweb-*
+  auth_file = occweb
   <content orbit>
     file = chandra_orbit.png
     convert = -transparent \#F0F1FF -crop 200x130+60+50 


### PR DESCRIPTION
Set to use Net::Netrc for credentials for get_iFOT_events and get_web_content occweb queries.

Also remove a broken DATA install in the Makefile and comment out installation of DATA from the Makefile.

Functional testing:

Copied appropriate credentials to kadi user .netrc and ran get_iFOT_events and get_web_content without credential errors.



