### PR TITLE
Mark missing proton channel data as -100000.0 instead of exiting

### DIFF
--- a/get_hrc.py
+++ b/get_hrc.py
@@ -102,9 +102,11 @@ def format_proton_data(dat, descrs):
 
     # Add the other channel data marking as 1.0e5 if missing
     for t in tabs:
-        # Take the second return of intersect1d as the mask of good data
-        ok = np.intersect1d(time_ref, t['time_tag'], assume_unique=True,
-                             return_indices=True)[1]
+        # Take the second return of intersect1d and make a mask of good data
+        ok = np.zeros(len(time_ref)).astype(bool)
+        idx_ok = np.intersect1d(time_ref, t['time_tag'], assume_unique=True,
+                                return_indices=True)[1]
+        ok[idx_ok] = True
         for col in channels:
             if col in t.colnames:
                 newdat[col][ok] = t[col]

--- a/get_hrc.py
+++ b/get_hrc.py
@@ -97,13 +97,6 @@ def format_proton_data(dat, descrs):
     newdat['dom'] = [t.day for t in times.datetime]
     newdat['hhmm'] = np.array([f"{t.hour}{t.minute:02}" for t in times.datetime]).astype(int)
 
-    hrc_shield = calc_hrc_shield(newdat)
-
-    newdat['hrc_shield'] = hrc_shield
-
-    hrc_bad = (newdat['p5'] < 0) | (newdat['p7'] < 0) | (newdat['p9'] < 0)
-    newdat['hrc_shield'][hrc_bad] = BAD_VALUE  # flag bad inputs
-
     # Take the Table and make it into an ndarray with the supplied type
     arr = np.ndarray(len(newdat), dtype=descrs)
     for col in arr.dtype.names:
@@ -113,6 +106,12 @@ def format_proton_data(dat, descrs):
             arr[col] = BAD_VALUE
         else:
             arr[col] = newdat[col]
+
+    # Calculate the hrc shield values using the numpy array and save into the array
+    hrc_shield = calc_hrc_shield(arr)
+    arr['hrc_shield'] = hrc_shield
+    hrc_bad = (arr['p5'] < 0) | (arr['p7'] < 0) | (arr['p9'] < 0)
+    arr['hrc_shield'][hrc_bad] = BAD_VALUE  # flag bad inputs
 
     return arr, hrc_bad
 

--- a/get_hrc.py
+++ b/get_hrc.py
@@ -17,6 +17,9 @@ URL_NOAA = 'https://services.swpc.noaa.gov/json/goes/primary/'
 URL_6H = f'{URL_NOAA}/differential-protons-6-hour.json'
 URL_7D = f'{URL_NOAA}/differential-protons-7-day.json'
 
+# Bad or missing data value
+BAD_VALUE = -1.0e5
+
 
 def get_options():
     parser = argparse.ArgumentParser(description='Archive GOES data and '
@@ -98,7 +101,7 @@ def format_proton_data(dat, descrs):
     newdat['month'] = [t.month for t in times.datetime]
     newdat['dom'] = [t.day for t in times.datetime]
     newdat['hhmm'] = np.array([f"{t.hour}{t.minute:02}" for t in times.datetime]).astype(int)
-    newdat['p11'] = np.full(len(times), -1.0e5)
+    newdat['p11'] = np.full(len(times), BAD_VALUE)
 
     # Add the other channel data marking as 1.0e5 if missing
     for t in tabs:
@@ -110,14 +113,14 @@ def format_proton_data(dat, descrs):
         for col in channels:
             if col in t.colnames:
                 newdat[col][ok] = t[col]
-                newdat[col][~ok] = -1.0e5
+                newdat[col][~ok] = BAD_VALUE
 
     hrc_shield = calc_hrc_shield(newdat)
 
     newdat['hrc_shield'] = hrc_shield
 
     hrc_bad = (newdat['p5'] < 0) | (newdat['p7'] < 0) | (newdat['p9'] < 0)
-    newdat['hrc_shield'][hrc_bad] = -1.0e5  # flag bad inputs
+    newdat['hrc_shield'][hrc_bad] = BAD_VALUE  # flag bad inputs
 
     return newdat, hrc_bad
 

--- a/get_hrc.py
+++ b/get_hrc.py
@@ -81,11 +81,8 @@ def format_proton_data(dat, descrs):
         t[channel] = t[channel] * 1000.0
         tabs.append(t)
 
-    # Get the union of times present in the per-channel tables
-    time_ref = set()
-    for t in tabs:
-        time_ref = time_ref.union(set(t['time_tag']))
-    time_ref = np.array(sorted(list(time_ref)))
+    # Get the unique times in the dat
+    time_ref = np.unique(dat['time_tag'])
 
     # Create a new table of the length of the union of the times
     newdat = np.ndarray(len(time_ref), dtype=descrs)

--- a/get_hrc.py
+++ b/get_hrc.py
@@ -84,7 +84,7 @@ def format_proton_data(dat, descrs):
     # Get the unique times in the dat
     time_ref = np.unique(dat['time_tag'])
 
-    # Create a new table of the length of the union of the times
+    # Create a new table of the length of the unique times
     newdat = np.ndarray(len(time_ref), dtype=descrs)
     newdat['satellite'] = tabs[0]['satellite'][0]
 


### PR DESCRIPTION
Mark missing proton channel data as -100000.0 instead of exiting

For the individual channel data, instead of a sys.exit if there is a missing entry for one or more of the channels for one of the times, this code creates the new time column and list of new records as the unique times in the new data, and indexes into those times with the channel data (setting any missing per-channel data to -100000.0 which seemed to be the convention).

If there is p5, p7, or p9 data that is negative, the row will be ignored for hrc by the other filtering (if I understand this correctly).

Fixes #57