### PR TITLE
Updated alert limits html page

### DIFF
--- a/alert_limits.html
+++ b/alert_limits.html
@@ -23,21 +23,19 @@
 <pre>
             Value        Description
            ----------    ------------------------
-  E150      800000       EPHIN E150
-  E1300       1000       EPHIN E1300
-  MCP A         30       HRC MCP event rate A
-  SHIELD A     250       HRC Antico Shield rate A
+  MCP B         30       HRC MCP event rate B
+  SHIELD B     250       HRC Antico Shield rate B
 
   ------------ NO LONGER IN RADMON ------------------
-  P4GM (GOES P2 * 3.3):      300.0      
-  P41GM (GOES P5 * 12):        8.47      
+  P4GM (GOES P4 * 3.3):      300.0
+  P41GM (GOES P7 * 12):        8.47
 </pre>
 Note: the units are not specified here but correspond to values normally seen
 in telemetry and the Chandra <a href="http://asc.harvard.edu/cgi-gen/mta/Snap/snap.cgi">Snapshot</a>.
 
 <h2> SOT ACE alerts </h2>
 <pre>
- ACE 130-214 keV proton flux (p/cm2-s-sr-MeV) and fluence (p/cm2-sr-MeV):
+ ACE 115-195 keV proton flux (p/cm2-s-sr-MeV) and fluence (p/cm2-sr-MeV):
 
                         SOT alert
   Average Flux:         (50000)  (2-hour fluence/7200)
@@ -65,21 +63,19 @@ in telemetry and the Chandra <a href="http://asc.harvard.edu/cgi-gen/mta/Snap/sn
 
                               OBSERVED     RADMON limit
                              ------------  -------------  
-     E150                                   800000
-     E1300                                    1000
-     MCP A                                      30     
-     SHIELD A                                  250
-     P4GM (GOES P2 * 3.3):                   (300.0)
-     P41GM (GOES P3 * 11):                    (8.47)
+     MCP B                                      30
+     SHIELD B                                  250
+     P4GM (GOES P4 * 3.3):                   (300.0)
+     P41GM (GOES P7 * 11):                    (8.47)
 
-- ACE 130-214 keV proton fluences (p/cm2-sr-MeV) and Costello 
+- ACE 115-195 keV proton fluences (p/cm2-sr-MeV) and Costello
   predicted activity index
 
                              OBSERVED      SOT alert
                              ------------  -------------
    2-hour Fluence:                         3.6E+8
    Orbital Fluence (CRM):                  1.0E+9
-   Kp:                                     6.0   
+   Kp:                                     6.0
 
 </pre>
       <hr>


### PR DESCRIPTION
This PR addresses Issue #41 and updates information in alert_limits.html.

- remove E150, E1300
- MCP A, replace with MCP B
- SHIELD A, replace with SHIELD B
- P4GM (GOES P2 * 3.3), replace with P4GM (GOES P4 * 3.3) (GOES-16 P4 roughly corresponds to the 'old' GOES P2 channel) 
- P4GM (GOES P5 * 12), replace with P4GM (GOES P7 * 12) (GOES-16 P7 roughly corresponds to the 'old' GOES P5 channel)
- ACE 130-214 keV, replace with 115-195 keV (current energies of the ACE P3 channel used for alerting)

Hopefully, this update can be included in the Replan Central installation following the ska3-shiny upgrade.

Not sure how to update the time tag and contact info - direct edit?