### PR TITLE
Improve warning message for not enough P3 values

### DIFF
--- a/make_timeline.py
+++ b/make_timeline.py
@@ -404,6 +404,8 @@ def main():
 
     # Plot 10, 50, 90 percentiles of fluence
     try:
+        if len(p3_times) < 4:
+            raise ValueError('not enough P3 values')
         p3_slope = get_p3_slope(p3_times, p3_vals)
         if p3_slope is not None and avg_flux > 0:
             p3_fits, p3_samps, fluences = cfd.get_fluences(


### PR DESCRIPTION
## Description

When there are no ACE P3 values this currently is not handled and gives a bad-looking exception:
```
<<2021-Oct-15 06:06>> WARNING: p3 fluence not plotted, error : index -1 is out of bounds for axis 0 with size 0
```
This fixes that.

## Testing

Realistic testing is difficult because it requires a large gap in ACE data. Since this is a very simple update, analysis of the code by at least 2 independent reviewers is sufficient.