### PR TITLE
Stop fetching and parsing thermal constraint file

### DIFF
--- a/arc.pl
+++ b/arc.pl
@@ -171,7 +171,7 @@ sub get_obsid_event {
     my $obsid = shift;
     my $snap  = shift;
     my $event = shift;
-    my $warn_msg = "Unable to include PCAD or thermal violation events";
+    my $warn_msg = "Unable to include PCAD violation events";
 
     my @obsid_evt = grep { defined $_->obsid } @{$event};
     my @index = grep { $obsid_evt[$_]->obsid == $obsid } (0..$#obsid_evt);
@@ -271,7 +271,7 @@ sub get_violation_events {
 	$load_name = $obsid_evt->load_segment->load_name;
     };
     if ($@) {
-	warning("Problem in get_violation_events, no PCAD or thermal violation events");
+	warning("Problem in get_violation_events, no PCAD violation events");
 	print STDERR "ERROR - $@";
 	return;
     }

--- a/arc.pl
+++ b/arc.pl
@@ -277,7 +277,6 @@ sub get_violation_events {
     }
     my @constraints;
     push @constraints, get_constraints($load_name, '');		# PCAD constraints
-    push @constraints, get_constraints($load_name, 'therm_');	# Thermal constraints
 
     my $constraint;
     for $constraint (@constraints) {


### PR DESCRIPTION
## Description

Stop fetching and parsing thermal constraint file.

The thermal constraint file is no longer created by FOT thermal as the outputs are no longer relevant / no longer based on models used by the FOT.  The file used to be included in the FOT approved products outputs.  

## Testing

- [n/a] Passes unit tests - unit tests have not been modernized and are presently disabled in Replan Central.
- [x] Functional Testing:
In a test version (see [wiki](https://github.com/sot/arc/wiki/Set-up-test-Replan-Central) for howto) this PR removed the warning "Could not find constraints file for any load version of therm_JAN1022" from the top and the load link was appropriately populated with the link to the approved JAN1022A directory.