### PR TITLE
Remove deprecated np.int and np.float

### DIFF
--- a/make_timeline.py
+++ b/make_timeline.py
@@ -288,7 +288,7 @@ def plot_multi_line(x, y, z, bins, colors, ax):
 
     # Allow specifying bin centers, not edges
     if len(bins) == len(colors):
-        bins = np.array(bins, dtype=np.float)
+        bins = np.array(bins, dtype=float)
         bins = np.concatenate([[z.min() - 1],
                                (bins[1:] + bins[:-1]) / 2.0,
                                [z.max() + 1]])
@@ -390,7 +390,7 @@ def main():
     # Make a z-valued curve where the z value corresponds to the grating state.
     x = cxc2pd(fluence_times)
     y = fluence
-    z = np.zeros(len(fluence_times), dtype=np.int)
+    z = np.zeros(len(fluence_times), dtype=int)
 
     for state in states:
         ok = ((state['tstart'] < fluence_times)
@@ -524,7 +524,7 @@ def main():
     y_si = -0.23
     x = cxc2pd(times)
     y = np.zeros_like(times) + y_si
-    z = np.zeros_like(times, dtype=np.float)  # 0 => ACIS
+    z = np.zeros_like(times, dtype=float)  # 0 => ACIS
     z[state_vals['simpos'] < 0] = 1.0  # HRC
     plot_multi_line(x, y, z, [0, 1], ['c', 'r'], ax)
     dx = (x1 - x0) * 0.01


### PR DESCRIPTION
## Description

Update np.int and np.float to just int and float.

## Testing

In a test environment based on ska3 flight latest 2022.2 this removes these warnings

```
kadi-fido> ./make_timeline.py --data-dir $SKA/data/arc3
./make_timeline.py:393: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  z = np.zeros(len(fluence_times), dtype=np.int)
./make_timeline.py:291: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  bins = np.array(bins, dtype=np.float)
./make_timeline.py:527: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  z = np.zeros_like(times, dtype=np.float)  # 0 => ACIS
./make_timeline.py:291: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  bins = np.array(bins, dtype=np.float)
```
And the timeline.png and timeline_states.js appear unchanged (but successfully made).