### PR TITLE
Fix bug in plot_multi_line for no grating state changes

### DIFF
--- a/make_timeline.py
+++ b/make_timeline.py
@@ -286,12 +286,12 @@ def plot_multi_line(x, y, z, bins, colors, ax):
     from matplotlib.collections import LineCollection
     from matplotlib.colors import ListedColormap, BoundaryNorm
 
-    # Allow specifying bin centers, not edges
+    # If there are the same number of bins as colors, infer that the
+    # bins are supplied as bin centers, and calculate the edges.
     if len(bins) == len(colors):
         bins = np.array(bins, dtype=float)
-        bins = np.concatenate([[z.min() - 1],
-                               (bins[1:] + bins[:-1]) / 2.0,
-                               [z.max() + 1]])
+        centers = (bins[1:] + bins[:-1]) / 2.0
+        bins = np.concatenate([[centers[0] - 1], centers, [centers[-1] + 1]])
 
     cmap = ListedColormap(colors)
     norm = BoundaryNorm(bins, cmap.N)


### PR DESCRIPTION
## Description

Fix bug in plot_multi_line which occurs when there are no grating state changes over the timeline time interval.

## Interface impact

None

## Testing

The current kadi states look to not have the issue (no gratings) that seems to bring this up.  I just set "z" (the grating state) to be all zeros and confirmed old code gives this error:
```
  File "/fido.real/kadi/arc3_test/lib/python3.8/site-packages/matplotlib/cm.py", line 455, in to_rgba
    x = self.norm(x)
  File "/fido.real/kadi/arc3_test/lib/python3.8/site-packages/matplotlib/colors.py", line 1801, in __call__
    iret = np.digitize(xx, self.boundaries) - 1 + self._offset
  File "<__array_function__ internals>", line 5, in digitize
  File "/fido.real/kadi/arc3_test/lib/python3.8/site-packages/numpy/lib/function_base.py", line 4852, in digitize
    raise ValueError("bins must be monotonically increasing or decreasing")
ValueError: bins must be monotonically increasing or decreasing
```
and new code doesn't
```
kadi-fido> ./make_timeline.py --data-dir=${SKA}/data/arc3
```

I put full test outputs in 

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/arc-pr71/

but they don't really show this issue and fix, they just show that the fix is not causing any other problems and that the timeline looks fine.

<img width="774" alt="Screen Shot 2022-05-02 at 2 31 27 PM" src="https://user-images.githubusercontent.com/791508/166305555-57e5e0bb-954e-44c6-8d82-aba787bcf50f.png">
