### PR TITLE
Update deprecation warning type for ska3-prime

### DIFF
--- a/make_timeline.py
+++ b/make_timeline.py
@@ -33,7 +33,7 @@ import warnings
 import matplotlib.cbook
 warnings.filterwarnings(
     'ignore',
-    category=matplotlib.cbook.mplDeprecation)
+    category=matplotlib.MatplotlibDeprecationWarning)
 
 
 


### PR DESCRIPTION
Update deprecation warning type for ska3-prime

Without this fix we get
```
/proj/sot/ska3/test/share/arc3/make_timeline.py:36: MatplotlibDeprecationWarning: mplDeprecation was deprecated in Matplotlib 3.6 and will be removed two minor releases later. Use matplotlib.MatplotlibDeprecationWarning instead.
  category=matplotlib.cbook.mplDeprecation)
```

I tested this and with the fix we don't get that warning.
