### PR TITLE
Remove short and long warning that we're not using

### DIFF
--- a/get_goes_x.py
+++ b/get_goes_x.py
@@ -92,8 +92,6 @@ def process_xray_data(dat, satellite=None):
     shortdat.rename_column('flux', 'short')
     longdat = dat[dat['energy'] == '0.1-0.8nm']['flux', 'satellite', 'time_tag']
     longdat.rename_column('flux', 'long')
-    if len(longdat) != len(shortdat):
-        print('Warning: "short" and "long" table have mismatched lengths')
 
     # Join them on time and satellite (seems to be OK for these data)
     joindat = join(shortdat, longdat)


### PR DESCRIPTION
Remove short and long warning that we're not using.

We aren't doing anything with the warning anyway, so it is just noise.  Originally there was the expectation that the data might be corrupted if the tables had mismatched lengths.  If that is happening, it doesn't seem to be having any impact.