### PR TITLE
Try more times for solar_wind png and increase warn delay

### DIFF
--- a/web_content.cfg
+++ b/web_content.cfg
@@ -70,9 +70,11 @@
   <solar_wind>
     url = https://space.umd.edu/pm/
     <image solar_wind>
+      tries = 5
+      sleep = 10
       file = solar_wind.png
       warn_bad_image = 1
-      warn_age_hours = 2
+      warn_age_hours = 4
       <filter>
         tag = img
         src = latest2day\.png


### PR DESCRIPTION
Try more times for solar_wind png and increase warn delay.

I'm hoping this reduces instances of 
```
Warning: 500 Can't connect to space.umd.edu:443 (Connection reset by peer) for web data solar_wind (https://space.umd.edu/pm/)
```
