### PR TITLE
Update get_ace to use format instead of Reader

### DIFF
--- a/get_ace.py
+++ b/get_ace.py
@@ -39,7 +39,7 @@ colnames = ('year month dom  hhmm  mjd secs '
 data_colnames = ('destat de1 de4 pstat p1 p3 p5 p6 p7').split()
 
 try:
-    dat = ascii.read(urldat, guess=False, Reader=ascii.NoHeader,
+    dat = ascii.read(urldat, guess=False, format="no_header",
                           data_start=3, names=colnames)
 except Exception as err:
     print(('Warning: malformed ACE data so table read failed: {}'


### PR DESCRIPTION
## Description

Update get_ace to use format instead of Reader

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This should stop all of the speedy-astropy warnings in the logs like
```
############################################################
/proj/sot/ska3/flight/share/arc3/get_ace.py --h5=/proj/sot/ska3/flight/data/arc3/ACE.h5
############################################################
<<2024-Mar-21 06:06>> WARNING: AstropyDeprecationWarning: "Reader" was deprecated in version 6.0 and will be removed in a future version.
<<2024-Mar-21 06:06>> Use "format" instead. [__main__]
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Functional testing
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I confirmed format and Reader gave the same table

format
```
year month dom hhmm  mjd   secs destat  de1   de4  pstat   p1    p3   p5   p6    p7  anis_idx
---- ----- --- ---- ----- ----- ------ ------ ---- ----- ------ ---- ---- ---- ----- --------
2024     3  22 1850 60391 67800      0 3090.0 40.2     0 3910.0 10.7 1.56 1.23  0.38     -1.0
2024     3  22 1855 60391 68100      0 3300.0 44.6     0 4000.0 12.6 1.93 1.31 0.437     -1.0
2024     3  22 1900 60391 68400      0 2980.0 45.4     0 4030.0 11.7 2.24 1.53 0.414     -1.0
2024     3  22 1905 60391 68700      0 3040.0 43.0     0 4030.0 12.8 1.77 1.62 0.381     -1.0
2024     3  22 1910 60391 69000      0 3140.0 51.5     0 3790.0 11.4  1.8 1.47 0.413     -1.0
2024     3  22 1915 60391 69300      0 3310.0 42.5     0 4060.0 12.0 1.92 1.68 0.661     -1.0
2024     3  22 1920 60391 69600      0 2980.0 42.2     0 4150.0 11.5  1.8 1.47 0.509     -1.0
2024     3  22 1925 60391 69900      0 3040.0 48.6     0 3740.0 11.4 1.59  1.5 0.554     -1.0
2024     3  22 1930 60391 70200      0 3320.0 42.6     0 4040.0 11.0  1.6 1.68 0.452     -1.0
2024     3  22 1935 60391 70500      0 3030.0 40.9     0 3990.0 12.4 1.97 1.57  0.47     -1.0
2024     3  22 1940 60391 70800      0 3080.0 45.8     0 4040.0 12.9 1.95 1.95 0.498     -1.0
2024     3  22 1945 60391 71100      0 3190.0 44.0     0 3920.0 13.1 1.51 2.06 0.428     -1.0
2024     3  22 1950 60391 71400      0 3270.0 48.0     0 4120.0 10.9 2.14  2.0 0.457     -1.0
2024     3  22 1955 60391 71700      0 3230.0 44.6     0 4040.0 11.1 1.82 1.66 0.479     -1.0
2024     3  22 2000 60391 72000      0 3170.0 40.0     0 3760.0 10.1 1.87 1.54 0.447     -1.0
2024     3  22 2005 60391 72300      0 3430.0 48.1     0 4000.0 12.9 1.89 1.48 0.451     -1.0
2024     3  22 2010 60391 72600      0 3040.0 43.0     0 4060.0 13.2 1.75 1.71 0.344     -1.0
2024     3  22 2015 60391 72900      0 3190.0 44.3     0 3900.0 11.5  2.0 1.61 0.364     -1.0
2024     3  22 2020 60391 73200      0 3480.0 38.7     0 4030.0 11.8 1.81 1.65 0.456     -1.0
2024     3  22 2025 60391 73500      0 3520.0 37.0     0 4010.0 10.4 2.01 2.09  0.53     -1.0
2024     3  22 2030 60391 73800      0 3200.0 38.1     0 4000.0 12.4 1.81 1.85 0.446     -1.0
2024     3  22 2035 60391 74100      0 3320.0 42.8     0 3800.0 10.1 1.73 1.56  0.44     -1.0
2024     3  22 2040 60391 74400      0 3410.0 42.2     0 4210.0 11.7 2.17 1.54  0.53     -1.0
```

Reader
```
WARNING: AstropyDeprecationWarning: "Reader" was deprecated in version 6.0 and will be removed in a future version. 
        Use "format" instead. [__main__]
year month dom hhmm  mjd   secs destat  de1   de4  pstat   p1    p3   p5   p6    p7  anis_idx
---- ----- --- ---- ----- ----- ------ ------ ---- ----- ------ ---- ---- ---- ----- --------
2024     3  22 1850 60391 67800      0 3090.0 40.2     0 3910.0 10.7 1.56 1.23  0.38     -1.0
2024     3  22 1855 60391 68100      0 3300.0 44.6     0 4000.0 12.6 1.93 1.31 0.437     -1.0
2024     3  22 1900 60391 68400      0 2980.0 45.4     0 4030.0 11.7 2.24 1.53 0.414     -1.0
2024     3  22 1905 60391 68700      0 3040.0 43.0     0 4030.0 12.8 1.77 1.62 0.381     -1.0
2024     3  22 1910 60391 69000      0 3140.0 51.5     0 3790.0 11.4  1.8 1.47 0.413     -1.0
2024     3  22 1915 60391 69300      0 3310.0 42.5     0 4060.0 12.0 1.92 1.68 0.661     -1.0
2024     3  22 1920 60391 69600      0 2980.0 42.2     0 4150.0 11.5  1.8 1.47 0.509     -1.0
2024     3  22 1925 60391 69900      0 3040.0 48.6     0 3740.0 11.4 1.59  1.5 0.554     -1.0
2024     3  22 1930 60391 70200      0 3320.0 42.6     0 4040.0 11.0  1.6 1.68 0.452     -1.0
2024     3  22 1935 60391 70500      0 3030.0 40.9     0 3990.0 12.4 1.97 1.57  0.47     -1.0
2024     3  22 1940 60391 70800      0 3080.0 45.8     0 4040.0 12.9 1.95 1.95 0.498     -1.0
2024     3  22 1945 60391 71100      0 3190.0 44.0     0 3920.0 13.1 1.51 2.06 0.428     -1.0
2024     3  22 1950 60391 71400      0 3270.0 48.0     0 4120.0 10.9 2.14  2.0 0.457     -1.0
2024     3  22 1955 60391 71700      0 3230.0 44.6     0 4040.0 11.1 1.82 1.66 0.479     -1.0
2024     3  22 2000 60391 72000      0 3170.0 40.0     0 3760.0 10.1 1.87 1.54 0.447     -1.0
2024     3  22 2005 60391 72300      0 3430.0 48.1     0 4000.0 12.9 1.89 1.48 0.451     -1.0
2024     3  22 2010 60391 72600      0 3040.0 43.0     0 4060.0 13.2 1.75 1.71 0.344     -1.0
2024     3  22 2015 60391 72900      0 3190.0 44.3     0 3900.0 11.5  2.0 1.61 0.364     -1.0
2024     3  22 2020 60391 73200      0 3480.0 38.7     0 4030.0 11.8 1.81 1.65 0.456     -1.0
2024     3  22 2025 60391 73500      0 3520.0 37.0     0 4010.0 10.4 2.01 2.09  0.53     -1.0
2024     3  22 2030 60391 73800      0 3200.0 38.1     0 4000.0 12.4 1.81 1.85 0.446     -1.0
2024     3  22 2035 60391 74100      0 3320.0 42.8     0 3800.0 10.1 1.73 1.56  0.44     -1.0
2024     3  22 2040 60391 74400      0 3410.0 42.2     0 4210.0 11.7 2.17 1.54  0.53     -1.0
```

And that a run of `get_ace.py --h5 /tmp/ACE.h5` ran without error.  I did not confirm the ACE.h5 content