### PR TITLE
Refactor and improve timeline testing infrastructure

### DIFF
--- a/make_timeline.py
+++ b/make_timeline.py
@@ -39,6 +39,8 @@ code, running both in "flight" mode::
   cd ..
   rsync -av t_now/ /proj/sot/ska/www/ASPECT_ICXC/test_review_outputs/arc/${PR}/t_now/
 
+  diff t_now/{flight,$COMMIT}/timeline_states.js
+
 Local
 -----
 Testing on a local machine (Mac) requires syncing the data files from kady.  This tests
@@ -62,11 +64,11 @@ ACE rates, and DSN comms from the web.
 Get the flight run date and convert that to a full date-format date (e.g. "317/1211z"
 => "2024:317:12:11:00")::
 
-  tail -c 400 t_now/flight/timeline_states.js | grep now_date
+  DATE_NOW=`python utils/get_date_now.py t_now/flight`
 
 Run the script with the test option::
 
-  python make_timeline.py --test --data-dir=t_now/$COMMIT --date-now=<now_date>
+  python make_timeline.py --test --data-dir=t_now/$COMMIT --date-now=$DATE_NOW
 
 To view the output, open the directory in a browser::
 
@@ -75,7 +77,10 @@ To view the output, open the directory in a browser::
 
 Compare the timeline_states.js files::
 
-  diff t_now/{flight,$COMMIT}/timeline_states.js
+  python utils/convert_states_to_yaml.py t_now/$COMMIT
+  python utils/convert_states_to_yaml.py t_now/flight
+
+  diff t_now/{flight,$COMMIT}/timeline_states.yaml
 """
 
 import argparse

--- a/make_timeline.py
+++ b/make_timeline.py
@@ -167,6 +167,7 @@ ace_rates_file = functools.partial(arc_data_file, "/data/mta4/www", "ace.html")
 dsn_comms_file = functools.partial(
     arc_data_file, SKA / "data" / "dsn_summary", "dsn_summary.yaml"
 )
+ace_hourly_avg_file = functools.partial(arc_data_file, DATA_ARC3, "ACE_hourly_avg.npy")
 goes_x_h5_file = functools.partial(arc_data_file, DATA_ARC3, "GOES_X.h5")
 ace_h5_file = functools.partial(arc_data_file, DATA_ARC3, "ACE.h5")
 hrc_h5_file = functools.partial(arc_data_file, DATA_ARC3, "hrc_shield.h5")
@@ -719,7 +720,7 @@ def draw_fluence_percentiles(
         p3_slope = get_p3_slope(p3_times, p3_vals)
         if p3_slope is not None and avg_flux > 0:
             p3_fits, p3_samps, fluences = cfd.get_fluences(
-                os.path.join(args.data_dir, "ACE_hourly_avg.npy")
+                ace_hourly_avg_file(args.data_dir, test=args.test),
             )
             hrs, fl10, fl50, fl90 = cfd.get_fluence_percentiles(
                 avg_flux,

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,8 +1,0 @@
-{
-    "ignore": [
-        "**/node_modules",
-        "**/__pycache__",
-        "**/*.ipynb",
-        ".git"
-    ]
-}

--- a/utils/convert_states_to_yaml.py
+++ b/utils/convert_states_to_yaml.py
@@ -1,0 +1,12 @@
+"""Convert timeline_states.js to YAML timeline_states.yaml for easier comparison."""
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+data_dir = sys.argv[1]
+text = Path(f"{data_dir}/timeline_states.js").read_text()
+states = json.loads(text[11:])
+yaml.dump(states, open(f"{data_dir}/timeline_states.yaml", "w"))

--- a/utils/get_date_now.py
+++ b/utils/get_date_now.py
@@ -1,0 +1,19 @@
+"""Convert the now_date from timeline_states.js to a CxoTime date string."""
+
+import json
+import sys
+from pathlib import Path
+
+from cxotime import CxoTime
+
+data_dir = sys.argv[1]
+text = Path(f"{data_dir}/timeline_states.js").read_text()
+data = json.loads(text[11:])
+
+# Get date like "319/1215z"
+now_date = data["now_date"]
+year = CxoTime.now().date[:4]
+
+# Convert now_date to "{year}:319:12:15:00"
+date = f"{year}:{now_date[0:3]}:{now_date[4:6]}:{now_date[6:8]}:00"
+print(date)


### PR DESCRIPTION
## Description

This improves the code structure for `make_timeline.py` and establishes a process for testing.

Highlights:
- Detailed test process with a couple of new utility scripts to help.
- Use dynamic file paths instead of hardwired global paths at import time.
  - In "flight" mode (without `--test`), input data file paths are hardwired to various paths available on HEAD
  - In "test" mode (with `--test`), input data files must all be in the directory defined by `--data-dir` (default `t_now`).
- Make module importable without side-effects.
- Add a function to grab some files from the web for testing and put them in the `--data-dir` directory.
- Use CxoTime instead of DateTime.
- Refactor `main()` into smaller drawing functions. This addresses a longstanding TODO, made easy now with VS code.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Functional testing
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
### On HEAD @ cf7febe
Followed the steps outlined in `make_timeline.py` for testing on HEAD. This was done with cf7febe. The only changes after that point are documentation or 55cc376 which does not impact the HEAD testing since the `--test-get-web` option is not used.

After the processing steps, the output timeline states are identical:
```
$ echo $COMMIT
cf7febe
$ diff t_now/{flight,$COMMIT}/timeline_states.js
$
```
HTML page outputs:
- https://icxc.cfa.harvard.edu/aspect/test_review_outputs/arc/pr86/t_now/cf7febe/timeline.png
- https://icxc.cfa.harvard.edu/aspect/test_review_outputs/arc/pr86/t_now/flight/timeline.png

### Local @ 55cc376
Followed the steps outlined in `make_timeline.py` for local testing on Mac. This was done with 55cc376. The only changes after that point are documentation or adding two test utility scripts.

After the processing steps, the output timeline states are nearly identical:
```
$ echo $COMMIT
55cc376
$ diff t_now/{flight,$COMMIT}/timeline_states.yaml    
10c10
< p3_avg_now: '81'
---
> p3_avg_now: '80'
3911c3911
<   fluence: 0.02e9
---
>   fluence: 0.01e9
```
I'm not 100% sure of the reason for the diff but I suspect that the ACIS fluence page updated in the middle of the test. The change in `p3_avg_now` (which comes from the ACIS fluence page) would propagate to a small change in `fluence` which is the predicted fluence assuming constant `p3_avg_now` flux. There are hundreds of states with a dozen state keys each, and they all match exactly except for this one.

The output web pages and `timeline.png` for the `flight` and `$COMMIT` cases are visually identical.