### PR TITLE
Add available comms to timeline plot

### DIFF
--- a/arc.pl
+++ b/arc.pl
@@ -528,6 +528,9 @@ sub make_web_page {
 
     $html .= $opt{timeline_html};
 
+    my $avail_comms_html < io("$TaskData/comms_avail.html");
+    $html .= $avail_comms_html;
+
     $html .= $q->p . make_event_table($event) . $q->p;
 
     $html .= HTML::Table->new(-align => 'center',

--- a/make_timeline.py
+++ b/make_timeline.py
@@ -288,12 +288,6 @@ def get_available_comms(start: CxoTime, stop: CxoTime) -> Table:
     )
     dat = dat[ok]
 
-    # Clip avail comms to be within start / stop
-    dat["avail_bot"] = np.where(
-        dat["avail_bot"] < datestart, datestart, dat["avail_bot"]
-    )
-    dat["avail_eot"] = np.where(dat["avail_eot"] > datestop, datestop, dat["avail_eot"])
-
     return dat["station", "avail_bot", "avail_eot"]
 
 
@@ -648,7 +642,7 @@ def main(args_sys=None):
         label1_size=10,
     )
 
-    draw_comms_avail(comms_avail, ax, x0, x1, y0, y1)
+    draw_comms_avail(comms_avail, ax, x0, x1)
     draw_goes_x_data(goes_x_times, goes_x_vals, ax)
     draw_ace_p3_and_limits(now, start, p3_times, p3_vals, ax)
     draw_hrc_proxy(hrc_times, hrc_vals, ax)

--- a/make_timeline.py
+++ b/make_timeline.py
@@ -125,6 +125,36 @@ URL_AVAIL_COMMS = (
     "https://occweb.cfa.harvard.edu/mission/MissionPlanning/DSN/DSN_Modifications.csv"
 )
 
+# Define HTML to support showing available comms as a table that is hidden by default.
+# The table content is inserted between the two. In a nicer world this would be in a
+# Jinja template, but let's keep the footprint small.
+COMMS_AVAIL_HTML_HEADER = """
+<script>
+    function toggleCommsAvail() {
+        var x = document.getElementById("timeline-comms-available");
+        var button = document.querySelector("button");
+        if (x.style.display === "none") {
+            x.style.display = "block";
+            button.textContent = "Hide available comms";
+        } else {
+            x.style.display = "none";
+            button.textContent = "Show available comms";
+        }
+    };
+</script>
+<div style="text-align: center;">
+    <button onclick="toggleCommsAvail()">Show available comms</button>
+</div>
+<div id="timeline-comms-available" style="display: none; font-family: monospace;">
+    <br>
+    <div style="display: flex; justify-content: center;">
+"""
+COMMS_AVAIL_HTML_FOOTER = """
+    </div>
+</div>
+<br>
+"""
+
 
 def cxc2pd(times: CxoTimeLike) -> float | np.ndarray:
     """
@@ -1012,11 +1042,13 @@ def write_comms_avail(comms_avail: Table, filename: str | Path):
     comms_avail.write(out, format="ascii.html")
     # Get the text between <table> and </table> and write out.
     match = re.search("<table>(.*)</table>", out.getvalue(), re.DOTALL)
-    Path(filename).write_text(match.group(0))
+    Path(filename).write_text(
+        COMMS_AVAIL_HTML_HEADER + match.group(0) + COMMS_AVAIL_HTML_FOOTER
+    )
 
 
 def write_states_json(
-    fn,
+    filename,
     fig,
     ax,
     states,
@@ -1142,7 +1174,7 @@ def write_states_json(
 
     # Finally write this all out as a simple javascript program that defines a single
     # variable ``data``.
-    with open(fn, "w") as f:
+    with open(filename, "w") as f:
         f.write("var data = {}".format(json.dumps(data)))
 
 

--- a/make_timeline.py
+++ b/make_timeline.py
@@ -1086,9 +1086,7 @@ def write_comms_avail(comms_avail_humans: Table | None, filename: str | Path) ->
         match = re.search("<table>(.*)</table>", out.getvalue(), re.DOTALL)
         text = match.group(0)
 
-    Path(filename).write_text(
-        COMMS_AVAIL_HTML_HEADER + text + COMMS_AVAIL_HTML_FOOTER
-    )
+    Path(filename).write_text(COMMS_AVAIL_HTML_HEADER + text + COMMS_AVAIL_HTML_FOOTER)
 
 
 def write_states_json(

--- a/make_timeline.py
+++ b/make_timeline.py
@@ -9,6 +9,10 @@ passages, instrument configuration.
 
 Testing
 =======
+This section documents regression testing of the Replan Central timeline plot code. For
+full testing of Replan Central including the ``arc.pl`` Perl script and other Python
+scripts see: https://github.com/sot/arc/wiki/Set-up-test-Replan-Central.
+
 First some setup which applies to testing both on HEAD and local::
 
   cd ~/git/arc

--- a/make_timeline.py
+++ b/make_timeline.py
@@ -142,6 +142,7 @@ COMMS_AVAIL_HTML_HEADER = """
         }
     };
 </script>
+<br>
 <div style="text-align: center;">
     <button onclick="toggleCommsAvail()">Show available comms</button>
 </div>
@@ -152,7 +153,6 @@ COMMS_AVAIL_HTML_HEADER = """
 COMMS_AVAIL_HTML_FOOTER = """
     </div>
 </div>
-<br>
 """
 
 


### PR DESCRIPTION
## Description

FOT MP maintains a table of "available comms", which means intervals when DSN stations are in view of Chandra and are not currently scheduled for another mission. This means they could likely be used by Chandra if needed.

This update to Replan Central uses that table of available comms to annotate the timeline plot accordingly. This will help with planning anomaly recovery efforts. This adds two new elements:
- A grey timeline strip to the bottom of the timeline plot and the text annotation `Avail comms` to the bottom right.
- A new table of available comms below the table of timeline status data. This table is hidden by default and can be toggled on/off with a button click.

Example output is at: https://cxc.cfa.harvard.edu/mta/ASPECT/tests/arc/pr87/arc3/

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
The Replan Central HTML and timeline PNG are updated according to the description.

## Functional testing
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
First followed instructions in the Wiki to create a testing environment on kadi and then the instructions below. This is done in the git repo at deae9ca.

Output: 
- Normal run: https://cxc.cfa.harvard.edu/mta/ASPECT/tests/arc/pr87/arc3/
- Zero length table: https://cxc.cfa.harvard.edu/mta/ASPECT/tests/arc/pr87/arc3/zero-len/
- Failed read of available comms URL: https://cxc.cfa.harvard.edu/mta/ASPECT/tests/arc/pr87/arc3/fail-read/

```
# Environment setup
export ska_dir=/export/tom/arc3_test
source ${ska_dir}/bin/activate
source ${ska_dir}/bin/ska_envs.sh

# Make sure the outputs are going to an expected directory
echo $SKA_DATA

# Install
make install

# Run through all jobs in task schedule
${SKA_SHARE}/arc3/get_iFOT_events.pl
${SKA_SHARE}/arc3/get_web_content.pl
${SKA_SHARE}/arc3/get_goes_x.py --h5=${SKA_DATA}/arc3/GOES_X.h5
${SKA_SHARE}/arc3/plot_goes_x.py --h5=${SKA_DATA}/arc3/GOES_X.h5 --out=${SKA}/www/ASPECT/arc3/goes_x.png
${SKA_SHARE}/arc3/get_ace.py --h5=${SKA_DATA}/arc3/ACE.h5
${SKA_SHARE}/arc3/get_hrc.py --h5=${SKA_DATA}/arc3/hrc_shield.h5 --data-dir=${SKA_DATA}/arc3
${SKA_SHARE}/arc3/plot_hrc.py --h5=${SKA_DATA}/arc3/hrc_shield.h5 --out=${SKA}/www/ASPECT/arc3/hrc_shield.png
${SKA_SHARE}/arc3/make_timeline.py --data-dir=${SKA_DATA}/arc3
${SKA_SHARE}/arc3/arc.pl
${SKA_SHARE}/arc3/arc.pl -config arc3:arc_ops
${SKA_SHARE}/arc3/arc_time_machine.pl

# Testing outputs for documentation
mkdir -p /proj/sot/ska/www/ASPECT/tests/arc/pr87/arc3

# Normal success
${SKA_SHARE}/arc3/make_timeline.py --data-dir=${SKA_DATA}/arc3
${SKA_SHARE}/arc3/arc.pl
rsync -av $SKA/www/ASPECT/arc3/ /proj/sot/ska/www/ASPECT/tests/arc/pr87/arc3/

# Failed read of available comms URL
env ARC_TEST_SCENARIO=avail-comms-read-fail ${SKA_SHARE}/arc3/make_timeline.py --data-dir=${SKA_DATA}/arc3
${SKA_SHARE}/arc3/arc.pl
rsync -av $SKA/www/ASPECT/arc3/ /proj/sot/ska/www/ASPECT/tests/arc/pr87/arc3/fail-read/

# Successful read but no available comms (zero-length table)
env ARC_TEST_SCENARIO=avail-comms-zero-len ${SKA_SHARE}/arc3/make_timeline.py --data-dir=${SKA_DATA}/arc3/
${SKA_SHARE}/arc3/arc.pl
rsync -av $SKA/www/ASPECT/arc3/ /proj/sot/ska/www/ASPECT/tests/arc/pr87/arc3/zero-len/
```
