### PR TITLE
Remove constraint violations

### DIFF
--- a/arc3.cfg
+++ b/arc3.cfg
@@ -63,7 +63,6 @@ query_name = eclipse
   blue_paper_test= blue_paper_test.gif
   web_content     = web_content.dat
   web_content_cfg = web_content.cfg
-  pcad_constraints = pcad_constraints
   timeline_png    = timeline.png
   timeline_js     = timeline.js
   timeline_css    = timeline.css
@@ -136,7 +135,7 @@ END_FORMAT
   col GOES
   col Limit
 </ephin_goes_table>
-  
+
 <ace_table>
   format %.1f
   footnote_style = font-size:85%
@@ -148,7 +147,7 @@ END_FORMAT
   col Orbital limit
   col Hours to<br>Orbital limit
 </ace_table>
-  
+
 # Define characteristics of event table:
 #  First set the types of events which get displayed, then the
 #  columns and column format characteristics
@@ -321,7 +320,7 @@ function refresh()
     //  page view history.  Most browsers will always retrieve
     //  the document from the web-server whether it is already
     //  in the browsers page-cache or not.
-    //  
+    //
     window.location.replace( sURL );
 }
 //-->
@@ -334,7 +333,7 @@ function refresh()
     //  This version of the refresh function will be invoked
     //  for browsers that support JavaScript version 1.2
     //
-    
+
     //  The argument to the location.reload function determines
     //  if the browser should retrieve the document from the
     //  web-server.  In our example all we need to do is cause
@@ -342,7 +341,7 @@ function refresh()
     //  re-evaluated.  If we needed to pull the document from
     //  the web-server again (such as where the document contents
     //  change dynamically) we would pass the argument as 'true'.
-    //  
+    //
     window.location.reload( false );
 }
 //-->


### PR DESCRIPTION
## Description

The constraint violations reported in Replan Central are no longer valid:

- SCS-107 no longer stops maneuvers, so the attitude-based and momentum violations are incorrect.
- Thermal violations are likewise inaccurate.
- Bright star hold is no longer allowed as a safing action; instead Normal Sun Mode is activated if stars are lost. That means the constraint violations for that attitude are not relevant.

The expectation is that the load product generation will remove these constraints from the report in a future release. This PR fixes Replan Central in advance of that change.

In the test outputs below, the `Earth Violation` and `High Momentum` constraint events (seen in flight) are no longer generated:
- https://cxc.cfa.harvard.edu/mta/ASPECT/tests/arc/pr88/arc3-test/
- https://cxc.cfa.harvard.edu/mta/ASPECT/tests/arc/pr88/arc3-flight/

The red notices in the test output for `HRC proxy data stale`, `P4GM data stale`, and `P41GM data stale` are expected as the test setup used stale data for these.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Incorrect constraint events are removed.

## Functional testing
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
This testing was run with data files left over from #87  (which is why there are warnings about stale data unrelated to the changes in the PR).

From the git repository in this branch:
```
# Environment setup
export ska_dir=/export/tom/arc3_test
source ${ska_dir}/bin/activate
source ${ska_dir}/bin/ska_envs.sh

# Make sure the outputs are going to an expected directory
echo $SKA_DATA

# Install
make install

# Run through perl jobs in task schedule. Python jobs (data collection, timelines) not impacted.
# This uses data files left over from PR 87.
${SKA_SHARE}/arc3/get_iFOT_events.pl
${SKA_SHARE}/arc3/get_web_content.pl
${SKA_SHARE}/arc3/arc.pl
${SKA_SHARE}/arc3/arc.pl -config arc3:arc_ops

# Copy test and current flight outputs for PR test documentation
mkdir -p /proj/sot/ska/www/ASPECT/tests/arc/pr88/arc3-test
rsync -av $SKA/www/ASPECT/arc3/ /proj/sot/ska/www/ASPECT/tests/arc/pr88/arc3-test/
rsync -av /proj/sot/ska/ASPECT/arc3/  /proj/sot/ska/www/ASPECT/tests/arc/pr88/arc3-flight/
```