### PR TITLE
Add requests checking and retry to solar flare fetch

### DIFF
--- a/get_solar_flare_png.py
+++ b/get_solar_flare_png.py
@@ -24,7 +24,12 @@ def get_options():
     return parser
 
 
-@retry.retry(exceptions=requests.exceptions.RequestException, delay=5, tries=3)
+@retry.retry(
+    exceptions=requests.exceptions.RequestException,
+    delay=5,
+    tries=3,
+    mangle_alert_words=True,
+)
 def get_last_referenced_web_image(
     url: str, img_src_pattern: str, cache_dir: str | Path
 ) -> Path:

--- a/get_solar_flare_png.py
+++ b/get_solar_flare_png.py
@@ -109,6 +109,8 @@ def main(sys_args=None):
 if __name__ == "__main__":
     try:
         main()
+    except requests.exceptions.HTTPError as e:
+        print(f"Failed to get page or image: {e}")
     except Exception:
         import traceback
 


### PR DESCRIPTION
## Description
Add requests checking and retry to solar flare fetch

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes issue/bug in https://github.com/sot/arc/pull/90 that a failed fetch will create a cached "image" file that is the http error response like
```
jeanconn-fido> more AR_CH_20250302.png 
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
<title>404 Not Found</title>
<style type="text/css"><!--
.style3 {
  font-family: Verdana, Arial, Helvetica, sans-serif;
  color: #CC0000;
}
.s {
  font-family: Verdana, Arial, Helvetica, sans-serif;
  font-size: 11px;
  font-weight: normal;
  color: #000000;
  line-height: 18px;
  text-align: center;
  border: 1px solid #CCCCCC;
  background-color: #FFFFEC;
}
body {
  background-color: #FFFFFF;
  margin-top: 100px;
}
--></style>
</head>
<body>
<div align="center">
<h2><span class="style3">404 Not Found</span></h2>
<table border="0" cellpadding="8" cellspacing="0" width="460">
<tbody><tr><td class="s">The requested URL was not found on this server.</td></tr></tbody>
</table>
</div>
</body>
</html>
```
## Functional testing
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I locally edited the script to change the value of img_url to a non-existent remote file, and confirmed that

1. the previously cached image was deleted/invalidated
2. the retry tried to get the file as requested
3. no new file was output into the cache directory

```
(ska3) flame:arc jean$ python get_solar_flare_png.py --image-cache-dir myretest --out-file new.png
WARN1NG: get_last_referenced_web_image(url=https://www.solen.info/solar/index.html, img_src_pattern=<img src=\"(images/AR_CH_\d{8}\.png)\", cache_dir=myretest) excepti0n: 404 Client Err0r: Not Found for url: https://www.solen.info/solar/images/AR_CH_20250303.png_broken, retrying in 5 seconds...
WARN1NG: get_last_referenced_web_image(url=https://www.solen.info/solar/index.html, img_src_pattern=<img src=\"(images/AR_CH_\d{8}\.png)\", cache_dir=myretest) excepti0n: 404 Client Err0r: Not Found for url: https://www.solen.info/solar/images/AR_CH_20250303.png_broken, retrying in 5 seconds...
Failed to get page or image: 404 Client Error: Not Found for url: https://www.solen.info/solar/images/AR_CH_20250303.png_broken
```





