### PR TITLE
Set solar flare fetch code to use copyfile not copy when updating the file

### DIFF
--- a/get_solar_flare_png.py
+++ b/get_solar_flare_png.py
@@ -108,7 +108,7 @@ def main(sys_args=None):
 
     # Copy the image to the standard name
     standard_image_path = Path(args.out_file)
-    shutil.copy(img_file, standard_image_path)
+    shutil.copyfile(img_file, standard_image_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Use copyfile not copy

The update script is run by multiple users, so copy() runs into issues with chmod and spits these into the log:

```
<<2025-Mar-24 06:11>> Traceback (most recent call last):
<<2025-Mar-24 06:11>> File "/proj/sot/ska3/flight/share/arc3/get_solar_flare_png.py", line 116, in
<<2025-Mar-24 06:11>> main()
<<2025-Mar-24 06:11>> File "/proj/sot/ska3/flight/share/arc3/get_solar_flare_png.py", line 111, in main
<<2025-Mar-24 06:11>> shutil.copy(img_file, standard_image_path)
<<2025-Mar-24 06:11>> File "/proj/sot/ska3/flight/lib/python3.12/shutil.py", line 436, in copy
<<2025-Mar-24 06:11>> copymode(src, dst, follow_symlinks=follow_symlinks)
<<2025-Mar-24 06:11>> File "/proj/sot/ska3/flight/lib/python3.12/shutil.py", line 317, in copymode
<<2025-Mar-24 06:11>> chmod_func(dst, stat.S_IMODE(st.st_mode))
<<2025-Mar-24 06:11>> PermissionError: [Errno 1] Operation not permitted: '/proj/sot/ska3/flight/www/ASPECT/arc3/solar_flare.png'
```


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Functional testing
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
On my mac I made a new tester user.

As jean user I did this
```
python get_solar_flare_png.py --image-cache-dir image_cache --out-file my_solar_flare.png
(ska3) flame:arc jean$ chmod g+w my_solar_flare.png 
(ska3) flame:arc jean$ chmod g+w image_cache/
(ska3) flame:arc jean$ chmod g+w image_cache/AR_CH_20250324.png 
```
And confirmed from master the error we get about chmod_func as a tester user in the staff group.
```
(ska3) tester@flame arc % python get_solar_flare_png.py --image-cache-dir image_cache --out-file my_solar_flare.png
Traceback (most recent call last):
  File "/Users/jean/git/arc/get_solar_flare_png.py", line 116, in <module>
    main()
  File "/Users/jean/git/arc/get_solar_flare_png.py", line 111, in main
    shutil.copy(img_file, standard_image_path)
  File "/Users/jean/miniforge3/envs/ska3/lib/python3.12/shutil.py", line 436, in copy
    copymode(src, dst, follow_symlinks=follow_symlinks)
  File "/Users/jean/miniforge3/envs/ska3/lib/python3.12/shutil.py", line 317, in copymode
    chmod_func(dst, stat.S_IMODE(st.st_mode))
PermissionError: [Errno 1] Operation not permitted: 'my_solar_flare.png'
```
And then checked out this PR code
```
(ska3) tester@flame arc % python get_solar_flare_png.py --image-cache-dir image_cache --out-file my_solar_flare.png
```
with no error.